### PR TITLE
Changes to enable the library to mostly work in Google App Engine

### DIFF
--- a/battlenet/__init__.py
+++ b/battlenet/__init__.py
@@ -1,6 +1,44 @@
-from .connection import *
-from .things import *
-from .exceptions import *
-from .utils import *
-from .enums import *
-from .constants import *
+from .connection import Connection
+
+from .constants import UNITED_STATES
+from .constants import EUROPE
+from .constants import KOREA
+from .constants import TAIWAN
+
+from .enums import RACE
+from .enums import CLASS
+from .enums import QUALITY
+from .enums import RACE_TO_FACTION
+
+from .exceptions import APIError
+from .exceptions import CharacterNotFound
+from .exceptions import GuildNotFound
+from .exceptions import RealmNotFound
+
+from .things import Thing
+from .things import LazyThing
+from .things import Character
+from .things import Title
+from .things import Reputation
+from .things import Stats
+from .things import Appearance
+from .things import Equipment
+from .things import Build
+from .things import Glyph
+from .things import Instance
+from .things import Boss
+from .things import Profession
+from .things import Pet
+from .things import Guild
+from .things import Emblem
+from .things import Perk
+from .things import Reward
+from .things import Realm
+from .things import EquippedItem
+from .things import Class
+from .things import Race
+
+from .utils import normalize
+from .utils import quote
+from .utils import make_icon_url
+from .utils import make_connection

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest as unittest
 import os
 import battlenet
 import datetime

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,8 @@
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest as unittest
 import os
 import battlenet
 

--- a/tests/test_eventlet.py
+++ b/tests/test_eventlet.py
@@ -1,35 +1,50 @@
-import unittest
-import eventlet
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest as unittest
+try:
+    ## If we can import eventlet go ahead and set up the connection to use eventlet.
+    ## Otherwise, don't set up the connection as we're not going to do this test.
+    import eventlet
+    battlenet.Connection.setup(public_key=PUBLIC_KEY, private_key=PRIVATE_KEY, eventlet=True)
+except:
+    pass
 import os
 import battlenet
 
 PUBLIC_KEY = os.environ.get('BNET_PUBLIC_KEY')
 PRIVATE_KEY = os.environ.get('BNET_PRIVATE_KEY')
 
-battlenet.Connection.setup(public_key=PUBLIC_KEY, private_key=PRIVATE_KEY, eventlet=True)
 
 
 class EventletTest(unittest.TestCase):
-    def setUp(self):
-        self.pool = eventlet.GreenPool()
+    try:
+        ## If we could load eventlet then go ahead and run the tests, otherwise just skip them.
+        import eventlet
 
-    def test_characters(self):
-        names = ['Stanislav', 'Vishnevskiy', 'Spruck', 'Marklevin', 'Tandisse']
+        def setUp(self):
+            self.pool = eventlet.GreenPool()
 
-        def get_character(name):
-            return battlenet.Character(battlenet.UNITED_STATES, 'Nazjatar', name)
+        def test_characters(self):
+            names = ['Stanislav', 'Vishnevskiy', 'Spruck', 'Marklevin', 'Tandisse']
 
-        for i, character in enumerate(self.pool.imap(get_character, names)):
-            self.assertEqual(character.name, names[i])
+            def get_character(name):
+                return battlenet.Character(battlenet.UNITED_STATES, 'Nazjatar', name)
 
-    def test_realms(self):
-        names = ['nazjatar', 'kiljaeden', 'blackrock', 'anubarak']
+            for i, character in enumerate(self.pool.imap(get_character, names)):
+                self.assertEqual(character.name, names[i])
 
-        def get_realm(name):
-            return battlenet.Realm(battlenet.UNITED_STATES, name)
+        def test_realms(self):
+            names = ['nazjatar', 'kiljaeden', 'blackrock', 'anubarak']
 
-        for i, realm in enumerate(self.pool.imap(get_realm, names)):
-            self.assertEqual(realm.slug, names[i])
+            def get_realm(name):
+                return battlenet.Realm(battlenet.UNITED_STATES, name)
+
+            for i, realm in enumerate(self.pool.imap(get_realm, names)):
+                self.assertEqual(realm.slug, names[i])
+    except:
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,8 @@
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest as unittest
 import os
 import battlenet
 

--- a/tests/test_guild.py
+++ b/tests/test_guild.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest as unittest
 import os
 import battlenet
 import datetime

--- a/tests/test_realm.py
+++ b/tests/test_realm.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest as unittest
 import battlenet
 from battlenet import Realm
 

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,4 +1,8 @@
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest as unittest
 import os
 import battlenet
 


### PR DESCRIPTION
These are changes to enable the library to mostly work in Google App Engine (GAE).

GAE uses Python 2.5 and and there are some issues to be worked around
1. A bug in 2.5 (the import of \* fails in **init**.py, so you have to manually import each item.
2. unittest had many features added in 2.7 so you have to import unittest2 as unittest if python is pre-2.7.
3. eventlet doesn't exist for GAE so those tests are excluded if the eventlet library fails to import.

Even with these changes there is still an issue with collections.namedtuple as that wasn't introduced until Python 2.6 so that test fails. Perhaps this needs to be changed in the library to support 2.5?

There are other failures that are visible in Python 2.7 as well as 2.5. These seem to be general errors that happen regardless of whether or not they are running in Google App Engine or not.

python2.7 test_data.py
  (500 internal server error)
  (diff is 1768 character long  ... self.maxDiff)
python2.7 test_character.py
  (CharacterNotFound)
  (AssertionError: datetime.datetime(2011, 1, 25, 15, 22, 8) != datetime.datetime(2011, 1, 25, 12, 22, 8))
  (AssertionError: u'Archaeology' != 'First Aid')

Thanks again for the library!
