### PR TITLE
The recent changes to connections.py are not Python 2.5 safe.

### DIFF
--- a/battlenet/connection.py
+++ b/battlenet/connection.py
@@ -101,12 +101,12 @@ class Connection(object):
         if self.eventlet and eventlet_urllib2:
             try:
                 response = eventlet_urllib2.urlopen(request)
-            except eventlet_urllib2.URLError as e:
+            except (eventlet_urllib2.URLError), e:
                 raise APIError(str(e))
         else:
             try:
                 response = urllib2.urlopen(request)
-            except urllib2.URLError as e:
+            except (urllib2.URLError), e:
                 raise APIError(str(e))
 
         try:


### PR DESCRIPTION
The recent changes to exceptions in connections.py are not syntax violations
in Python 2.5. The "as" keyword wasn't introduced until 2.6 so I've changed
this to the older syntax that works in both 2.5 and 2.6+. This change is
required for the code to run in Google App Engine.
http://docs.python.org/whatsnew/2.6.html#pep-3110-exception-handling-changes
