### PR TITLE
Fixing the handling of blank talent tree names / icons + More unicode changes

### DIFF
--- a/battlenet/things.py
+++ b/battlenet/things.py
@@ -509,12 +509,14 @@ class Equipment(Thing):
 
 class Build(Thing):
     def __init__(self, character, data):
+        NONE = 'None'
+        NOICON = 'inv_misc_questionmark' # The infamous macro 'question mark' icon, because Blizzard uses it in this situation.
         self._character = character
         self._data = data
 
         self.build = data['build']
-        self.icon = data.get('icon')
-        self.name = data['name']
+        self.icon = data.get('icon') if self.build.strip('0') else NOICON
+        self.name = data['name'] if self.build.strip('0') else NONE
         self.selected = data.get('selected', False)
         self.glyphs = {
             'prime': [],
@@ -530,7 +532,7 @@ class Build(Thing):
         self.trees = [Tree(**tree) for tree in data['trees']]
 
     def __str__(self):
-        return self.name + ' (%d/%d/%d' % tuple(map(operator.attrgetter('total'), self.trees))
+        return self.name + ' (%d/%d/%d)' % tuple(map(operator.attrgetter('total'), self.trees))
 
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, str(self))

--- a/battlenet/utils.py
+++ b/battlenet/utils.py
@@ -4,13 +4,13 @@ import urllib
 
 def normalize(name):
     if not isinstance(name, unicode):
-        name = name.encode('utf8')
+        name = unicode(name)
 
-    return unicodedata.normalize('NFKC', name).encode('utf8')
+    return unicodedata.normalize('NFKC', name)
 
 
 def quote(name):
-    return urllib.quote(normalize(name))
+    return urllib.quote(normalize(name).encode('utf8'))
 
 
 def make_icon_url(region, icon, size='large'):


### PR DESCRIPTION
- Blank talent trees now have 'None' as build name, the icon used with an empty build is now the question mark, as Blizzard does the same.
- Corrected a small display error when showing builds ( the trailing ')' was missing after the talent numbers )

This fixes issue #3 ( https://github.com/vishnevskiy/battlenet/issues/3 ) , although the naming of blank trees is debatable..

Edit: Come to think of it, calling it plainly 'Untalented' would probably be a lot better.

This also cleans up the mess I created with the previous pull request, I have absolutely no clue why I decided not to run a full batch of tests on that 'fix'.

Signed-off-by: Crote laurxp@gmail.com
